### PR TITLE
Ensure correlation ID resets after each request

### DIFF
--- a/src/CorrelationIdMiddleware.php
+++ b/src/CorrelationIdMiddleware.php
@@ -33,6 +33,7 @@ final class CorrelationIdMiddleware implements MiddlewareInterface
         if (!$response->hasHeader(self::HEADER_NAMES[0])) {
             $response = $response->withHeader(self::HEADER_NAMES[0], $id);
         }
+        CorrelationIdProvider::clear();
         return $response;
     }
 

--- a/src/CorrelationIdProvider.php
+++ b/src/CorrelationIdProvider.php
@@ -17,4 +17,9 @@ final class CorrelationIdProvider
     {
         return self::$correlationId;
     }
+
+    public static function clear(): void
+    {
+        self::$correlationId = '';
+    }
 }

--- a/src/Symfony/CorrelationIdSubscriber.php
+++ b/src/Symfony/CorrelationIdSubscriber.php
@@ -41,6 +41,7 @@ final class CorrelationIdSubscriber implements EventSubscriberInterface
         if (!$response->headers->has('X-Correlation-ID')) {
             $response->headers->set('X-Correlation-ID', $id);
         }
+        CorrelationIdProvider::clear();
     }
 
     private function extractId(Request $request): string

--- a/tests/CorrelationIdSubscriberTest.php
+++ b/tests/CorrelationIdSubscriberTest.php
@@ -35,6 +35,7 @@ final class CorrelationIdSubscriberTest extends TestCase
         $subscriber->onResponse($responseEvent);
 
         self::assertSame('abc', $responseEvent->getResponse()->headers->get('X-Correlation-ID'));
+        self::assertSame('', CorrelationIdProvider::get());
     }
 
     public function testGeneratesIdWhenHeaderMissing(): void
@@ -55,5 +56,6 @@ final class CorrelationIdSubscriberTest extends TestCase
         $subscriber->onResponse($responseEvent);
 
         self::assertSame($id, $responseEvent->getResponse()->headers->get('X-Correlation-ID'));
+        self::assertSame('', CorrelationIdProvider::get());
     }
 }


### PR DESCRIPTION
## Summary
- add a `clear()` helper to `CorrelationIdProvider`
- reset the ID in `CorrelationIdMiddleware` and `CorrelationIdSubscriber`
- test that IDs are cleared once a response is produced

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse --error-format=table`


------
https://chatgpt.com/codex/tasks/task_e_6845b0b18a048320aae56a481722acda